### PR TITLE
Support port mapping other than 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,19 +17,6 @@ RUN Write-Host 'Downloading Nuget Server'; \
 	Write-Host 'Extracting Nuget Server'; \
 	Expand-Archive web.zip -DestinationPath C:\NugetServer; \
 	Write-Host 'Removing zip'; \
-	Remove-Item web.zip; \
-	Write-Host 'Creating IIS site'; \
-	Import-module IISAdministration; \
-	New-IISSite -Name "NugetServer" -PhysicalPath C:\NugetServer -BindingInformation "*:8080:";  \
-	icacls C:\packages /grant 'IIS AppPool\DefaultAppPool:(OI)(CI)M';
-
-HEALTHCHECK CMD powershell -command   \
-    try { \
-     $response = iwr http://localhost:8080 -UseBasicParsing; \
-     if ($response.StatusCode -eq 200) { return 0} \
-     else {return 1}; \
-    } catch { return 1 }
-
-EXPOSE 8080
+	Remove-Item web.zip;
 	
 ENTRYPOINT ./startup.ps1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ Example usage:
 ```PowerShell
 docker run --name NugetServer -d -p 8080:8080 -v C:/NugetServer/Packages:C:/packages -e API_KEY=**generate_your_key** vvucetic/nuget-server:latest 
 ```
-**Please note that you need to generate API KEY and provide in env variable like in example.**
+
+```PowerShell
+docker run --name NugetServer -d -p 80:80 -v C:/NugetServer/Packages:C:/packages -e NUGET_PORT=80 -e API_KEY=**generate_your_key** vvucetic/nuget-server:latest 
+```
+**Please note that you need to generate API KEY and provide in env variable like in example. And, make sure that NUGET_PORT has the same value as port mapped.**
 
 ## Inspect IP of container
 

--- a/startup.ps1
+++ b/startup.ps1
@@ -1,3 +1,14 @@
+Write-Host 'Stop the default web site';
+Stop-IISSite -Name 'Default Web Site' -Confirm:$false
+
+$Port = 8080
+if (![string]::IsNullOrEmpty($env:NUGET_PORT)) { $Port = $env:NUGET_PORT }
+
+Write-Host 'Creating IIS site';
+Import-module IISAdministration;
+New-IISSite -Name "NugetServer" -PhysicalPath C:\NugetServer -BindingInformation "*:$Port:";
+icacls C:\packages /grant 'IIS AppPool\DefaultAppPool:(OI)(CI)M';
+
 Write-Host 'Configuring ApiKey';
 
 $value = "";


### PR DESCRIPTION
When binding Nuget service to host ports other than 8080, I have to create IIS site NugetServer which also binds to that port since Nuget.Server generates package URL using the port IIS site bound. I removed Health Check form Dockerfile and move New-IISSite to the entrypoint script. And,  the default IIS site is stopped to prevent port conflicts.